### PR TITLE
Added one Line in the Gitignore for Mac OS Workspace 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ lib/generated_plugin_registrant.dart
 
 # Exceptions to above rules.
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+
+#Ios Runner workspace
+ios/Runner.xcworkspace


### PR DESCRIPTION
War nötig weil der Xcode workspace sich relativ häufig ändert. 