### PR TITLE
Die Links zu der About us page hinzugefügt 

### DIFF
--- a/lib/page/about/about.dart
+++ b/lib/page/about/about.dart
@@ -116,12 +116,6 @@ class _AboutPageState extends State<AboutPage> {
                 _launchURL('https://fridaysforfuture.de');
               },
             ),
-            ListTile(
-              title: Text('Unterstützung 💵'),
-              onTap: (){
-                _launchURL('https://fridaysforfuture.de/spenden/');
-              },
-            ),
             _buildTitle('Sonstiges'),
             ListTile(
               title: Text('Impressum 📖'),


### PR DESCRIPTION
Ich hab jetzt erstmal Spenden in Unterstützen geändert da keine Spenden Links im App Store erlaubt sind. Wir müssen das allerdings generell nochmal besprechen wie wir das machen. Ist jetzt nur eine Lösung bis zur nächsten TK