### PR TITLE
rename og settings headline

### DIFF
--- a/lib/page/about/settings.dart
+++ b/lib/page/about/settings.dart
@@ -57,7 +57,7 @@ class _SettingsPageState extends State<SettingsPage> {
                 }),
           ),
           if (Hive.box('subscribed_ogs').isNotEmpty)
-            TitleWidget('Abonnierte OGs'),
+            TitleWidget('Abonnierte Ortsgruppen'),
           for (OG og in Hive.box('subscribed_ogs').values)
             ListTile(
               title: Text(og.name),


### PR DESCRIPTION
In der Beta-Umfrage wurde gebeten, keine Abkürzungen wie "OG" zu verwenden.