### PR TITLE
Anzeige der App Version

### DIFF
--- a/lib/page/about/about.dart
+++ b/lib/page/about/about.dart
@@ -1,6 +1,7 @@
 import 'package:app/model/post.dart';
 import 'package:app/page/about/settings.dart';
 import 'package:app/page/feed/post.dart';
+import 'package:package_info/package_info.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:app/app.dart';
 import 'package:app/widget/title.dart';
@@ -14,8 +15,6 @@ class AboutPage extends StatefulWidget {
 }
 
 class _AboutPageState extends State<AboutPage> {
-
-
   _launchURL(String url) async {
     if (await canLaunch(url)) {
       await launch(url);
@@ -85,6 +84,22 @@ class _AboutPageState extends State<AboutPage> {
             TitleWidget('Sonstiges'),
             _buildListTile('📖 Impressum', 'impressum'),
             _buildListTile('📑 Datenschutz', 'datenschutz'),
+            Center(
+              child: FutureBuilder<PackageInfo>(
+                future: PackageInfo.fromPlatform(),
+                builder: (context, result) {
+                  if (!result.hasData) return SizedBox();
+
+                  return Text(
+                    'App Version ${result.data.version}',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Theme.of(context).hintColor,
+                    ),
+                  );
+                },
+              ),
+            )
           ],
         ),
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -485,6 +485,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.2"
+  package_info:
+    dependency: "direct main"
+    description:
+      name: package_info
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0+16"
   package_resolver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
   hive_flutter: ^0.3.0+2
   flutter_offline: ^0.3.0
   flutter_map_marker_cluster: ^0.2.7
+  package_info: '>=0.4.0+16 <2.0.0'
+
   
   
 dev_dependencies:


### PR DESCRIPTION
Auf der `Über uns` Seite wird jetzt die App Version angezeigt, damit wir bei Fehlermeldungen genauere Infos bekommen und alte App Versionen als Ursache ausschließen können