### PR TITLE
pubspeck.lock aktualisiert

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -232,6 +232,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.9"
+  email_validator:
+    dependency: "direct main"
+    description:
+      name: email_validator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
+  expandable:
+    dependency: "direct main"
+    description:
+      name: expandable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.1.3"
   firebase_dynamic_links:
     dependency: "direct main"
     description:
@@ -903,6 +924,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.20"
   xml:
     dependency: transitive
     description:


### PR DESCRIPTION
es wurden neue pakete hinzugefügt ohne die änderungen in pubspeck.lock anzupassen.
dieser PR holt das nach