### PR TITLE
display whatsapp social link

### DIFF
--- a/lib/widget/og_social_buttons.dart
+++ b/lib/widget/og_social_buttons.dart
@@ -137,6 +137,8 @@ class SocialButtons extends StatelessWidget {
       SocialLink(
           MdiIcons.telegram, 'Telegram Gruppe öffnen', container.telegram),
       SocialLink(
+          MdiIcons.whatsapp, 'WhatsApp Gruppe öffnen', container.whatsapp),
+      SocialLink(
           MdiIcons.instagram, 'Instagram Kanal öffnen', container.instagram),
       SocialLink(MdiIcons.youtube, 'YouTube Kanal öffnen', container.youtube),
       SocialLink(MdiIcons.twitter, 'Twitter Kanal öffnen', container.twitter),


### PR DESCRIPTION
auf der og-info seite fehlte nach dem letzten umbau die whatsapp gruppe bei den social links